### PR TITLE
Ensure cash flow view updates after new entries

### DIFF
--- a/client/src/components/cash-flow/transaction-form.tsx
+++ b/client/src/components/cash-flow/transaction-form.tsx
@@ -31,7 +31,11 @@ export function TransactionForm() {
         title: "Sucesso",
         description: "Lançamento criado com sucesso!",
       });
-      queryClient.invalidateQueries({ queryKey: ["/api/caixa"] });
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          typeof query.queryKey[0] === "string" &&
+          query.queryKey[0].startsWith("/api/caixa"),
+      });
       form.reset({
         tipo: TipoLancamento.Entrada,
         categoria: "",

--- a/client/src/components/orders/order-form.tsx
+++ b/client/src/components/orders/order-form.tsx
@@ -42,6 +42,11 @@ export function OrderForm({ isOpen, onClose }: OrderFormProps) {
         description: "Pedido criado com sucesso!",
       });
       queryClient.invalidateQueries({ queryKey: ["/api/pedidos"] });
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          typeof query.queryKey[0] === "string" &&
+          query.queryKey[0].startsWith("/api/caixa"),
+      });
       onClose();
       form.reset();
       setQuantities({});


### PR DESCRIPTION
## Summary
- Refresh cash flow data after creating a new order
- Invalidate cash flow queries after manual transaction creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68abe2c18898832b8c45b31f6413dfe5