### PR TITLE
Support partial order payments before completion

### DIFF
--- a/client/src/components/orders/order-table.tsx
+++ b/client/src/components/orders/order-table.tsx
@@ -4,6 +4,7 @@ import { StatusPedido, type PedidoComItens } from "../../../../shared/schema";
 import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { ShippingModal } from "./shipping-modal";
+import { PaymentModal } from "./payment-modal";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -35,6 +36,10 @@ export function OrderTable({ pedidos }: OrderTableProps) {
     pedidoId: "",
     pedidoNumero: "",
   });
+  const [paymentModal, setPaymentModal] = useState<{ isOpen: boolean; pedido: PedidoComItens | null }>({
+    isOpen: false,
+    pedido: null,
+  });
 
   const updateStatusMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: string }) =>
@@ -64,11 +69,25 @@ export function OrderTable({ pedidos }: OrderTableProps) {
     });
   };
 
+  const handlePayment = (pedido: PedidoComItens) => {
+    setPaymentModal({
+      isOpen: true,
+      pedido,
+    });
+  };
+
   const closeShippingModal = () => {
     setShippingModal({
       isOpen: false,
       pedidoId: "",
       pedidoNumero: "",
+    });
+  };
+
+  const closePaymentModal = () => {
+    setPaymentModal({
+      isOpen: false,
+      pedido: null,
     });
   };
 
@@ -192,7 +211,7 @@ export function OrderTable({ pedidos }: OrderTableProps) {
                         <Button
                           size="sm"
                           variant="outline"
-                          onClick={() => updateStatusMutation.mutate({ id: pedido.id, status: 'Concluido' })}
+                          onClick={() => handlePayment(pedido)}
                           disabled={updateStatusMutation.isPending}
                           className="text-green-600 hover:text-green-900"
                           data-testid={`button-concluir-${pedido.id}`}
@@ -235,6 +254,11 @@ export function OrderTable({ pedidos }: OrderTableProps) {
         onClose={closeShippingModal}
         pedidoId={shippingModal.pedidoId}
         pedidoNumero={shippingModal.pedidoNumero}
+      />
+      <PaymentModal
+        isOpen={paymentModal.isOpen}
+        onClose={closePaymentModal}
+        pedido={paymentModal.pedido}
       />
     </div>
   );

--- a/client/src/components/orders/payment-modal.tsx
+++ b/client/src/components/orders/payment-modal.tsx
@@ -1,0 +1,176 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { api } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { X, DollarSign } from "lucide-react";
+import { TipoLancamento, type PedidoComItens } from "../../../../shared/schema";
+
+const paymentSchema = z.object({
+  valor: z.number().min(0.01, "Valor deve ser maior que zero"),
+});
+
+type PaymentData = z.infer<typeof paymentSchema>;
+
+interface PaymentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  pedido: PedidoComItens | null;
+}
+
+export function PaymentModal({ isOpen, onClose, pedido }: PaymentModalProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const form = useForm<PaymentData>({
+    resolver: zodResolver(paymentSchema),
+    defaultValues: { valor: 0 },
+  });
+
+  const { data: lancamentos = [] } = useQuery({
+    queryKey: ["/api/caixa/lancamentos", pedido?.id],
+    queryFn: () => api.caixa.lancamentos(undefined, undefined, pedido!.id),
+    enabled: isOpen && !!pedido,
+  });
+
+  const totalPedido = pedido
+    ? pedido.itens.reduce((sum, item) => sum + item.quantidade * item.precoUnitario, 0)
+    : 0;
+  const totalPago = lancamentos
+    .filter((l) => l.tipo === TipoLancamento.Entrada)
+    .reduce((sum, l) => sum + l.valor, 0);
+  const restante = totalPedido - totalPago;
+
+  const paymentMutation = useMutation({
+    mutationFn: async (data: PaymentData) => {
+      return api.caixa.createLancamento({
+        tipo: TipoLancamento.Entrada,
+        categoria: "Receita de Venda",
+        valor: data.valor,
+        pedidoId: pedido!.id,
+      });
+    },
+    onSuccess: async (_, variables) => {
+      const novoTotalPago = totalPago + variables.valor;
+      if (novoTotalPago >= totalPedido) {
+        try {
+          await api.pedidos.updateStatus(pedido!.id, "Concluido");
+        } catch (error: any) {
+          toast({
+            title: "Erro",
+            description: error.message || "Erro ao concluir pedido",
+            variant: "destructive",
+          });
+        }
+      }
+      toast({
+        title: "Sucesso",
+        description: "Pagamento registrado com sucesso!",
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/pedidos"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/caixa"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/caixa/lancamentos", pedido!.id] });
+      form.reset({ valor: 0 });
+      onClose();
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erro",
+        description: error.message || "Erro ao registrar pagamento",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: PaymentData) => {
+    if (data.valor > restante) {
+      toast({
+        title: "Erro",
+        description: "Valor excede o restante a pagar",
+        variant: "destructive",
+      });
+      return;
+    }
+    paymentMutation.mutate(data);
+  };
+
+  const handleClose = () => {
+    form.reset({ valor: 0 });
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-lg font-semibold text-gray-900 flex items-center">
+              <DollarSign className="w-5 h-5 mr-2" />
+              Registrar Pagamento {pedido?.numero}
+            </DialogTitle>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClose}
+              className="text-gray-400 hover:text-gray-600"
+              data-testid="button-close-modal"
+            >
+              <X className="w-6 h-6" />
+            </Button>
+          </div>
+        </DialogHeader>
+
+        {pedido && (
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="text-sm text-gray-700">
+              <p>Total do Pedido: R$ {totalPedido.toFixed(2).replace('.', ',')}</p>
+              <p>Pago: R$ {totalPago.toFixed(2).replace('.', ',')}</p>
+              <p>Restante: R$ {restante.toFixed(2).replace('.', ',')}</p>
+            </div>
+
+            <div>
+              <Label htmlFor="valor" className="block text-sm font-medium text-gray-700 mb-1">
+                Valor do Pagamento
+              </Label>
+              <Input
+                id="valor"
+                type="number"
+                step="0.01"
+                min="0"
+                {...form.register("valor", { valueAsNumber: true })}
+                placeholder="0,00"
+                data-testid="input-valor-pagamento"
+              />
+              {form.formState.errors.valor && (
+                <p className="text-sm text-red-600 mt-1">{form.formState.errors.valor.message}</p>
+              )}
+            </div>
+
+            <div className="flex justify-end space-x-3 pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+                data-testid="button-cancelar"
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                disabled={paymentMutation.isPending}
+                data-testid="button-registrar-pagamento"
+              >
+                {paymentMutation.isPending ? "Registrando..." : "Registrar Pagamento"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -54,11 +54,12 @@ export const api = {
 
   // Caixa
   caixa: {
-    lancamentos: (start?: string, end?: string): Promise<LancamentoCaixa[]> => {
+    lancamentos: (start?: string, end?: string, pedidoId?: string): Promise<LancamentoCaixa[]> => {
       const params = new URLSearchParams();
       if (start) params.append('start', start);
       if (end) params.append('end', end);
-      
+      if (pedidoId) params.append('pedidoId', pedidoId);
+
       const url = `/api/caixa/lancamentos${params.toString() ? `?${params}` : ''}`;
       return fetch(url).then(res => res.json());
     },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -133,8 +133,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Caixa endpoints
   app.get("/api/caixa/lancamentos", async (req, res) => {
     try {
-      const { start, end } = req.query;
-      const lancamentos = await storage.getLancamentosCaixa(start as string, end as string);
+      const { start, end, pedidoId } = req.query;
+      const lancamentos = await storage.getLancamentosCaixa(start as string, end as string, pedidoId as string);
       res.json(lancamentos);
     } catch (error) {
       res.status(500).json({ message: "Erro interno do servidor" });


### PR DESCRIPTION
## Summary
- add modal to register payments and finish orders when fully paid
- open payment modal from order table instead of directly concluding
- allow cash ledger queries filtered by order

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68abe577e758832b8ebc5a51b7c6f0ba