### PR TITLE
Remove caixa entries when cancelling orders

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -324,6 +324,14 @@ class SQLiteStorage implements IStorage {
         }).run();
       }
 
+      // Se cancelado, remover lançamentos relacionados ao pedido
+      if (novoStatus === StatusPedido.Cancelado) {
+        this.drizzle
+          .delete(lancamentosCaixa)
+          .where(eq(lancamentosCaixa.pedidoId, id))
+          .run();
+      }
+
     })();
 
     return await this.getPedido(id);


### PR DESCRIPTION
## Summary
- remove caixa entries when cancelling orders so no production cost remains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68abed5c1964832b99eaadab6b16bb87