### PR TITLE
Increase body parser limits for larger payloads

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,8 +3,8 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: "2mb" }));
+app.use(express.urlencoded({ extended: false, limit: "2mb" }));
 
 app.use((req, res, next) => {
   const start = Date.now();


### PR DESCRIPTION
## Summary
- raise Express JSON and URL-encoded body limits to 2 MB

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run dev` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68abf4d47e9c832bb643f4b088dfa783