### PR TITLE
Remove botão de fechar duplicado nos modais e adiciona endpoint de criação de usuários

### DIFF
--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -44,10 +43,6 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertPedidoSchema, insertLancamentoCaixaSchema, insertProdutoSchema, StatusPedido } from "../shared/schema";
+import { insertPedidoSchema, insertLancamentoCaixaSchema, insertProdutoSchema, insertUsuarioSchema, StatusPedido } from "../shared/schema";
 import { z } from "zod";
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -160,6 +160,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const resumo = await storage.getResumoCaixa(start as string, end as string);
       res.json(resumo);
     } catch (error) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  });
+
+  // Admin endpoints
+  app.post("/api/admin/usuarios", async (req, res) => {
+    try {
+      const validatedData = insertUsuarioSchema.parse(req.body);
+      const usuario = await storage.createUsuario(validatedData);
+      res.status(201).json(usuario);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: "Dados inválidos", errors: error.errors });
+      }
       res.status(500).json({ message: "Erro interno do servidor" });
     }
   });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -16,6 +16,11 @@ export const TipoLancamento = {
   Saida: 2
 } as const;
 
+export const UserRole = {
+  Admin: "Admin",
+  Usuario: "Usuario",
+} as const;
+
 // Tables
 export const produtos = sqliteTable("produtos", {
   id: integer("id").primaryKey(),
@@ -54,6 +59,12 @@ export const lancamentosCaixa = sqliteTable("lancamentos_caixa", {
   comprovante: text("comprovante"),
 });
 
+export const usuarios = sqliteTable("usuarios", {
+  id: integer("id").primaryKey(),
+  nome: text("nome").notNull(),
+  role: text("role").notNull(),
+});
+
 // Insert Schemas
 export const insertProdutoSchema = createInsertSchema(produtos).omit({
   id: true,
@@ -84,6 +95,10 @@ export const insertLancamentoCaixaSchema = createInsertSchema(lancamentosCaixa).
   comprovante: z.string().optional(),
 });
 
+export const insertUsuarioSchema = createInsertSchema(usuarios)
+  .omit({ id: true })
+  .extend({ role: z.enum([UserRole.Admin, UserRole.Usuario]) });
+
 // Types
 export type InsertProduto = z.infer<typeof insertProdutoSchema>;
 export type Produto = typeof produtos.$inferSelect;
@@ -96,6 +111,9 @@ export type ItemPedido = typeof itensPedido.$inferSelect;
 
 export type InsertLancamentoCaixa = z.infer<typeof insertLancamentoCaixaSchema>;
 export type LancamentoCaixa = typeof lancamentosCaixa.$inferSelect;
+
+export type InsertUsuario = z.infer<typeof insertUsuarioSchema>;
+export type Usuario = typeof usuarios.$inferSelect;
 
 // API Response Types
 export type PedidoComItens = Pedido & {


### PR DESCRIPTION
## Summary
- remove X extra do componente de dialog para evitar dois botões de fechar
- adiciona tabela de usuários e endpoint de administração para criar contas com roles limitadas

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68abfdcd3cc8832bb64f10b5234994e4