### PR TITLE
feat: add user creation page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ server/public
 vite.config.ts.*
 *.tar.gz
 *.tsx
+!client/src/pages/users.tsx

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from "@/components/layout/sidebar";
 import Orders from "@/pages/orders";
 import CashFlow from "@/pages/cash-flow";
 import Products from "@/pages/products";
+import Users from "@/pages/users";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -15,6 +16,7 @@ function Router() {
       <Route path="/" component={Orders} />
       <Route path="/caixa" component={CashFlow} />
       <Route path="/produtos" component={Products} />
+      <Route path="/usuarios" component={Users} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -1,11 +1,12 @@
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
-import { FileText, DollarSign, Package } from "lucide-react";
+import { FileText, DollarSign, Package, Users } from "lucide-react";
 
 const navigation = [
   { name: "Pedidos", href: "/", icon: FileText },
   { name: "Fluxo de Caixa", href: "/caixa", icon: DollarSign },
   { name: "Produtos", href: "/produtos", icon: Package },
+  { name: "Usuários", href: "/usuarios", icon: Users },
 ];
 
 export function Sidebar() {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -3,10 +3,12 @@ import type {
   Produto, 
   PedidoComItens, 
   LancamentoCaixa, 
-  ResumoCaixa, 
-  InsertPedido, 
+  ResumoCaixa,
+  InsertPedido,
   InsertLancamentoCaixa,
-  InsertProduto
+  InsertProduto,
+  InsertUsuario,
+  Usuario
 } from "../../../shared/schema";
 
 export const api = {
@@ -76,6 +78,14 @@ export const api = {
       
       const url = `/api/caixa/resumo${params.toString() ? `?${params}` : ''}`;
       return fetch(url).then(res => res.json());
+    },
+  },
+
+  // Usuarios
+  usuarios: {
+    create: async (usuario: InsertUsuario): Promise<Usuario> => {
+      const response = await apiRequest("POST", "/api/admin/usuarios", usuario);
+      return response.json();
     },
   },
 };

--- a/client/src/pages/users.tsx
+++ b/client/src/pages/users.tsx
@@ -1,0 +1,119 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { insertUsuarioSchema, type InsertUsuario, UserRole } from "../../../shared/schema";
+import { api } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { Header } from "@/components/layout/header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+export default function Users() {
+  const { toast } = useToast();
+
+  const form = useForm<InsertUsuario>({
+    resolver: zodResolver(insertUsuarioSchema),
+    defaultValues: {
+      nome: "",
+      role: UserRole.Usuario,
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: api.usuarios.create,
+    onSuccess: () => {
+      toast({
+        title: "Sucesso",
+        description: "Usuário criado com sucesso!",
+      });
+      form.reset({ nome: "", role: UserRole.Usuario });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erro",
+        description: error.message || "Erro ao criar usuário",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: InsertUsuario) => {
+    mutation.mutate(data);
+  };
+
+  return (
+    <div className="flex-1 overflow-hidden">
+      <Header
+        title="Usuários"
+        subtitle="Crie novos usuários do sistema"
+      />
+
+      <div className="p-6 overflow-y-auto h-full">
+        <Card className="max-w-md">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-gray-900">
+              Novo Usuário
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <div>
+                <Label htmlFor="nome" className="block text-sm font-medium text-gray-700 mb-1">
+                  Nome
+                </Label>
+                <Input
+                  id="nome"
+                  {...form.register("nome")}
+                  placeholder="Nome do usuário"
+                  data-testid="input-nome-usuario"
+                />
+                {form.formState.errors.nome && (
+                  <p className="text-sm text-red-600 mt-1">
+                    {form.formState.errors.nome.message}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">
+                  Perfil
+                </Label>
+                <Select
+                  value={form.watch("role")}
+                  onValueChange={(value) => form.setValue("role", value as InsertUsuario["role"])}
+                >
+                  <SelectTrigger id="role" data-testid="select-role">
+                    <SelectValue placeholder="Selecione um perfil" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={UserRole.Admin}>Admin</SelectItem>
+                    <SelectItem value={UserRole.Usuario}>Usuario</SelectItem>
+                  </SelectContent>
+                </Select>
+                {form.formState.errors.role && (
+                  <p className="text-sm text-red-600 mt-1">
+                    {form.formState.errors.role.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex justify-end pt-2">
+                <Button
+                  type="submit"
+                  disabled={mutation.isPending}
+                  data-testid="button-criar-usuario"
+                >
+                  {mutation.isPending ? "Salvando..." : "Criar Usuário"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API wrapper for creating users
- add navigation and route for users
- create page with form to register users

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac0322f110832b84451c7f3facfa6b