### PR TITLE
feat: add login and role-based access control

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,20 +9,34 @@ import CashFlow from "@/pages/cash-flow";
 import Products from "@/pages/products";
 import Users from "@/pages/users";
 import NotFound from "@/pages/not-found";
+import Login from "@/pages/login";
+import { AuthProvider, useAuth } from "@/hooks/use-auth";
+import { UserRole } from "../../shared/schema";
 
 function Router() {
+  const { user } = useAuth();
   return (
     <Switch>
       <Route path="/" component={Orders} />
-      <Route path="/caixa" component={CashFlow} />
-      <Route path="/produtos" component={Products} />
-      <Route path="/usuarios" component={Users} />
+      {user?.role === UserRole.Admin && (
+        <>
+          <Route path="/caixa" component={CashFlow} />
+          <Route path="/produtos" component={Products} />
+          <Route path="/usuarios" component={Users} />
+        </>
+      )}
       <Route component={NotFound} />
     </Switch>
   );
 }
 
-function App() {
+function AppContent() {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <Login />;
+  }
+
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
@@ -36,4 +50,10 @@ function App() {
   );
 }
 
-export default App;
+export default function App() {
+  return (
+    <AuthProvider>
+      <AppContent />
+    </AuthProvider>
+  );
+}

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -1,16 +1,23 @@
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 import { FileText, DollarSign, Package, Users } from "lucide-react";
-
-const navigation = [
-  { name: "Pedidos", href: "/", icon: FileText },
-  { name: "Fluxo de Caixa", href: "/caixa", icon: DollarSign },
-  { name: "Produtos", href: "/produtos", icon: Package },
-  { name: "Usuários", href: "/usuarios", icon: Users },
-];
+import { useAuth } from "@/hooks/use-auth";
+import { UserRole } from "../../../../shared/schema";
 
 export function Sidebar() {
   const [location] = useLocation();
+  const { user } = useAuth();
+
+  const navigation = [
+    { name: "Pedidos", href: "/", icon: FileText },
+    ...(user?.role === UserRole.Admin
+      ? [
+          { name: "Fluxo de Caixa", href: "/caixa", icon: DollarSign },
+          { name: "Produtos", href: "/produtos", icon: Package },
+          { name: "Usuários", href: "/usuarios", icon: Users },
+        ]
+      : []),
+  ];
 
   return (
     <aside className="w-64 bg-white shadow-lg">

--- a/client/src/components/orders/order-form.tsx
+++ b/client/src/components/orders/order-form.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { insertPedidoSchema, type InsertPedido, type Produto } from "../../../../shared/schema";
+import { insertPedidoSchema, type InsertPedido, type Produto, UserRole } from "../../../../shared/schema";
 import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,6 +21,7 @@ export function OrderForm({ isOpen, onClose }: OrderFormProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [quantities, setQuantities] = useState<Record<number, number>>({});
+  const { user } = useAuth();
 
   const { data: produtos = [] } = useQuery({
     queryKey: ["/api/produtos"],
@@ -185,20 +187,24 @@ export function OrderForm({ isOpen, onClose }: OrderFormProps) {
                   R$ {summary.receita.toFixed(2).replace('.', ',')}
                 </span>
               </div>
-              <div className="flex justify-between text-sm">
-                <span className="text-gray-600">COGS Estimado:</span>
-                <span className="font-medium text-gray-900" data-testid="text-cogs-estimado">
-                  R$ {summary.cogs.toFixed(2).replace('.', ',')}
-                </span>
-              </div>
-              <div className="border-t pt-2">
-                <div className="flex justify-between text-sm font-medium">
-                  <span className="text-gray-900">Margem Estimada:</span>
-                  <span className="text-green-600" data-testid="text-margem-estimada">
-                    R$ {summary.margem.toFixed(2).replace('.', ',')}
-                  </span>
-                </div>
-              </div>
+              {user?.role === UserRole.Admin && (
+                <>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-600">COGS Estimado:</span>
+                    <span className="font-medium text-gray-900" data-testid="text-cogs-estimado">
+                      R$ {summary.cogs.toFixed(2).replace('.', ',')}
+                    </span>
+                  </div>
+                  <div className="border-t pt-2">
+                    <div className="flex justify-between text-sm font-medium">
+                      <span className="text-gray-900">Margem Estimada:</span>
+                      <span className="text-green-600" data-testid="text-margem-estimada">
+                        R$ {summary.margem.toFixed(2).replace('.', ',')}
+                      </span>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           </div>
 

--- a/client/src/components/orders/order-table.tsx
+++ b/client/src/components/orders/order-table.tsx
@@ -1,12 +1,13 @@
 import { useState, Fragment } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { StatusPedido, type PedidoComItens } from "../../../../shared/schema";
+import { StatusPedido, type PedidoComItens, UserRole } from "../../../../shared/schema";
 import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { ShippingModal } from "./shipping-modal";
 import { PaymentModal } from "./payment-modal";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { useAuth } from "@/hooks/use-auth";
 import {
   Table,
   TableBody,
@@ -31,6 +32,7 @@ const statusLabels: Record<number, { label: string; variant: "secondary" | "defa
 export function OrderTable({ pedidos }: OrderTableProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
   const [shippingModal, setShippingModal] = useState<{ isOpen: boolean; pedidoId: string; pedidoNumero: string }>({
     isOpen: false,
     pedidoId: "",
@@ -211,7 +213,7 @@ export function OrderTable({ pedidos }: OrderTableProps) {
                   </TableCell>
                   <TableCell>
                     <div className="flex space-x-2">
-                      {canTransition(pedido.status, 'Enviado') && (
+                      {canTransition(pedido.status, 'Enviado') && user?.role === UserRole.Admin && (
                         <Button
                           size="sm"
                           variant="outline"
@@ -235,7 +237,7 @@ export function OrderTable({ pedidos }: OrderTableProps) {
                           Concluir
                         </Button>
                       )}
-                      {canTransition(pedido.status, 'Cancelado') && (
+                      {canTransition(pedido.status, 'Cancelado') && user?.role === UserRole.Admin && (
                         <Button
                           size="sm"
                           variant="outline"

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+import type { Usuario } from "../../../shared/schema";
+import { api } from "@/lib/api";
+
+interface AuthContextType {
+  user: Usuario | null;
+  login: (nome: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<Usuario | null>(() => {
+    const stored = localStorage.getItem("user");
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  const login = async (nome: string) => {
+    const u = await api.auth.login(nome);
+    setUser(u);
+    localStorage.setItem("user", JSON.stringify(u));
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem("user");
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -91,4 +91,11 @@ export const api = {
       return fetch("/api/usuarios").then(res => res.json());
     },
   },
+
+  auth: {
+    login: async (nome: string): Promise<Usuario> => {
+      const response = await apiRequest("POST", "/api/login", { nome });
+      return response.json();
+    },
+  },
 };

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,44 @@
+import { useForm } from "react-hook-form";
+import { useAuth } from "@/hooks/use-auth";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface LoginData {
+  nome: string;
+}
+
+export default function Login() {
+  const { login } = useAuth();
+  const { toast } = useToast();
+  const { register, handleSubmit } = useForm<LoginData>();
+
+  const onSubmit = async (data: LoginData) => {
+    try {
+      await login(data.nome);
+    } catch (error: any) {
+      toast({
+        title: "Erro",
+        description: error.message || "Usuário não encontrado",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold text-gray-900">Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <Input placeholder="Nome de usuário" {...register("nome", { required: true })} />
+            <Button type="submit" className="w-full">Entrar</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -181,6 +181,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.post("/api/login", async (req, res) => {
+    try {
+      const { nome } = req.body;
+      if (!nome) {
+        return res.status(400).json({ message: "Nome de usuário é obrigatório" });
+      }
+      const usuario = await storage.getUsuarioByNome(nome);
+      if (!usuario) {
+        return res.status(401).json({ message: "Usuário não encontrado" });
+      }
+      res.json(usuario);
+    } catch (error) {
+      res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  });
+
   app.get("/api/usuarios/", async (req, res) => {
     try {
       const usuarios = await storage.getUsuarios();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -46,6 +46,7 @@ export interface IStorage {
   // Usuários
   createUsuario(usuario: InsertUsuario): Promise<Usuario>;
   getUsuarios(): Promise<Usuario[]>;
+  getUsuarioByNome(nome: string): Promise<Usuario | undefined>;
 }
 
 class SQLiteStorage implements IStorage {
@@ -380,6 +381,15 @@ class SQLiteStorage implements IStorage {
   async getUsuarios(): Promise<Usuario[]> {
     let query = this.drizzle.select().from(usuarios);
     return query.all();
+  }
+
+  async getUsuarioByNome(nome: string): Promise<Usuario | undefined> {
+    const result = this.drizzle
+      .select()
+      .from(usuarios)
+      .where(eq(usuarios.nome, nome))
+      .get();
+    return result || undefined;
   }
 
   async createLancamentoCaixa(lancamento: InsertLancamentoCaixa): Promise<LancamentoCaixa> {


### PR DESCRIPTION
## Summary
- add username-based login endpoint and client authentication hooks
- restrict navigation and actions based on user role
- hide cost details from non-admin users

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac0fa90a3c832b83300faf245cd6d9