### PR TITLE
feat: cria usuário admin por padrão

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -134,6 +134,22 @@ class SQLiteStorage implements IStorage {
         (2, 'SUPORTE_GRANDE', 35.00, 15.00, 1);
       `);
     }
+
+    // Seed default admin user
+    const adminExists = this.db
+      .prepare('SELECT COUNT(*) as count FROM usuarios WHERE nome = ?')
+      .get('admin') as { count: number };
+
+    if (adminExists.count === 0) {
+      const maxUserId = this.db
+        .prepare('SELECT MAX(id) as maxId FROM usuarios')
+        .get() as { maxId: number | null };
+      const nextUserId = (maxUserId?.maxId || 0) + 1;
+
+      this.db
+        .prepare('INSERT INTO usuarios (id, nome, role) VALUES (?, ?, ?)')
+        .run(nextUserId, 'admin', 'Admin');
+    }
   }
 
   async getProdutos(): Promise<Produto[]> {


### PR DESCRIPTION
## Summary
- adiciona seed para criar usuário padrão `admin` com role de administrador

## Testing
- `npm test` (falhou: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac14eac4b8832baac0f06f33a279cd